### PR TITLE
Add recipient specific email buckets and API filtering

### DIFF
--- a/src/pages/emails.ts
+++ b/src/pages/emails.ts
@@ -1,7 +1,12 @@
 import { type APIRoute } from "astro";
-import { emails } from "./index.ts";
+import { emails, emailsByRecipient } from "./index.ts";
 
 export const GET: APIRoute = async ({ request }) => {
+  const url = new URL(request.url)
+  if (url.searchParams.has('recipient')) {
+    return new Response(JSON.stringify(emailsByRecipient[url.searchParams.get('recipient')] || []));
+  }
+  
   return new Response(JSON.stringify(emails));
 };
 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -10,6 +10,7 @@ export type EmailType = {
 };
 
 export const emails: EmailType[] = [];
+export const emailsByRecipient: Record<string, EmailType[]> = {};
 
 export const GET: APIRoute = async ({ request }) => {
   return Response.redirect(`${request.url}logs`);
@@ -30,7 +31,10 @@ export const POST: APIRoute = async ({ params, request }) => {
   const text = data.get("Message.Body.Text.Data") || "";
   const html = data.get("Message.Body.Html.Data") || "";
 
-  emails.push({ from, to, subject, text, html, date: new Date() });
+  const now = new Date();
+  emails.push({ from, to, subject, text, html, date: now });
+  emailsByRecipient[to] = emailsByRecipient[to] || []
+  emailsByRecipient[to].push({ from, to, subject, text, html, date: now })
 
   const sendEmailResponse = `
     <SendEmailResponse xmlns="https://ses.amazonaws.com/doc/2010-12-01/">


### PR DESCRIPTION
This is a great start for a simple local tool, matching what I'm using for DynamoDB, thanks for putting in the effort to make this!

What I think would be nice, is to use this tool also for automated tests, to ensure that the email has been sent somewhat correctly, but that brings a couple of requirements for me;
* It needs to handle _a lot_ of emails (might do some more work on this later)
* It needs to be able to fetch emails only for a specific recipient (the purpose of this PR)

So that's what this PR does; adds a bucket for emails per recipient, and adds some very basic filtering capabilities to the endpoint to fetch these.
Let me know what you think about this, if you don't like this approach, I can keep my own fork :)