### PR TITLE
Prevent text overlapping on email list items

### DIFF
--- a/src/components/EmailListItem.tsx
+++ b/src/components/EmailListItem.tsx
@@ -11,7 +11,7 @@ export function EmailListItem(props: EmailListItemProps) {
   return (
     <div className="border rounded-md overflow-hidden relative bg-white">
       <div className="px-4 border-b py-2 flex flex-col gap-0.5">
-        <div className="flex items-center">
+        <div className="flex items-center pr-36">
           <span className="uppercase text-xs mr-2 text-gray-400 block w-[70px] relative top-[0.5px]">
             From
           </span>


### PR DESCRIPTION
If the sender name is really long, it overlaps the date of the email:

![image](https://github.com/kamranahmedse/local-ses/assets/1180644/ace72781-2540-460f-b5f5-c0d864bf1d44)

This simple fix just adds some padding to prevent that:

![image](https://github.com/kamranahmedse/local-ses/assets/1180644/0d33466c-e19b-42a9-a309-c4b9a49ee4b6)

Might be visually prettier to rather truncate the text, but then you lose out on information, so kind of a personal preference thing, not sure what you think about it?